### PR TITLE
Added a mixin to trigger UI injection in player menus

### DIFF
--- a/src/main/java/com/lowdragmc/lowdraglib2/core/mixins/ui/InventoryMenuMixin.java
+++ b/src/main/java/com/lowdragmc/lowdraglib2/core/mixins/ui/InventoryMenuMixin.java
@@ -1,0 +1,34 @@
+package com.lowdragmc.lowdraglib2.core.mixins.ui;
+
+import com.lowdragmc.lowdraglib2.gui.event.ContainerMenuEvent;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.inventory.InventoryMenu;
+import net.neoforged.neoforge.common.NeoForge;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(InventoryMenu.class)
+public abstract class InventoryMenuMixin {
+    @Inject(method = "<init>", at = @At("RETURN"))
+    private void ldlib2$onInit(Inventory playerInventory, boolean active, Player owner, CallbackInfo ci) {
+        if (owner.level().isClientSide) {
+            // Client-safe scheduling
+            net.minecraft.client.Minecraft.getInstance().execute(() -> {
+                NeoForge.EVENT_BUS.post(
+                        new ContainerMenuEvent.Create(owner, (InventoryMenu)(Object)this)
+                );
+            });
+        } else {
+            // Server-safe scheduling
+            owner.level().getServer().execute(() -> {
+                NeoForge.EVENT_BUS.post(
+                        new ContainerMenuEvent.Create(owner, (InventoryMenu)(Object)this)
+                );
+            });
+        }
+    }
+}

--- a/src/main/resources/ldlib2.mixins.json
+++ b/src/main/resources/ldlib2.mixins.json
@@ -47,7 +47,8 @@
     "kjs.ServerScriptManagerAccessor",
     "ui.AbstractContainerMenuMixin",
     "ui.MenuTypeMixin",
-    "ui.ServerPlayerMixin"
+    "ui.ServerPlayerMixin",
+    "ui.InventoryMenuMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
# Issue

Injecting UI into existing menus did not work for the players inventory menu. Turns out the inventory menu is created through a separate method and therefore never touches the MenuTypeMixin.

# Fix

I added a new mixin that calls the `ContainerMenuEvent.Create` event during creation of the players inventory menu. The event is scheduled to be called when it is safe to do so, to prevent crashes/errors during login.