### PR TITLE
Fix typo causing invalid layout height in some cases

### DIFF
--- a/src/main/java/com/lowdragmc/lowdraglib2/gui/ui/ModularUI.java
+++ b/src/main/java/com/lowdragmc/lowdraglib2/gui/ui/ModularUI.java
@@ -560,7 +560,7 @@ public class ModularUI {
             if (taffyTree.isDirty(ui.rootElement.nodeId)) {
                 taffyTree.computeLayout(ui.rootElement.nodeId, new TaffySize<>(
                         Float.isNaN(layoutWidth) ? AvailableSpace.MAX_CONTENT : AvailableSpace.definite(layoutWidth),
-                        Float.isNaN(layoutWidth) ? AvailableSpace.MAX_CONTENT : AvailableSpace.definite(layoutHeight)
+                        Float.isNaN(layoutHeight) ? AvailableSpace.MAX_CONTENT : AvailableSpace.definite(layoutHeight)
                 ));
 
                 for (var nodeId : nodesWithNewLayout) {


### PR DESCRIPTION
I'm guessing this was a typo? 😄 

The second tuple element checks Float.isNaN(layoutWidth) instead of Float.isNaN(layoutHeight). As a result, whenever the root element's WIDTH style is fixed (LENGTH/AUTO rather than PERCENT), init() sets layoutWidth = NaN and Taffy gets MAX_CONTENT as the height available space too — even when layoutHeight is a perfectly valid screenHeight.

A root with width(LENGTH).heightPercent(100) ends up sized to its content height instead of the screen height. Children with flex(1) stop being constrained, scrollers think their content fits (no scroll), and anything in-flow at the bottom of a flex-column root gets pushed off-screen.