### PR TITLE
修复FluidSlot无法放入流体

### DIFF
--- a/src/main/java/com/lowdragmc/lowdraglib2/gui/ui/elements/FluidSlot.java
+++ b/src/main/java/com/lowdragmc/lowdraglib2/gui/ui/elements/FluidSlot.java
@@ -387,7 +387,7 @@ public class FluidSlot extends BindableUIElement<FluidStack> {
             var access = ItemAccess.forPlayerCursor(player, menu);
             var handler = access.getCapability(Capabilities.Fluid.ITEM);
             if (handler == null) return;
-            var initialFluid = handler.getResource(tankIndex).toStack(handler.getAmountAsInt(tankIndex));
+            var initialFluid = container.getResource(0).toStack(container.getAmountAsInt(0));
             if (allowClickFilled && container.getAmountAsInt(0) > 0) {
                 var performedFill = false;
                 try (var trans = Transaction.openRoot()) {


### PR DESCRIPTION
前面已经进行了container = RangedResourceHandler.of(container, tankIndex, tankIndex + 1);变换，所以后面不用tankIndex了