### PR TITLE
fix(jei): register xeiRecipeSlot as real JEI layout slots

### DIFF
--- a/src/main/java/com/lowdragmc/lowdraglib2/gui/ui/elements/FluidSlot.java
+++ b/src/main/java/com/lowdragmc/lowdraglib2/gui/ui/elements/FluidSlot.java
@@ -298,7 +298,7 @@ public class FluidSlot extends BindableUIElement<FluidStack> {
     public FluidSlot xeiRecipeSlot(IngredientIO io, float chance) {
         // todo xei
         if (LDLib2.isJeiLoaded()) {
-            JEISupport.recipeSlot(this);
+            JEISupport.recipeSlot(this, io);
         }
 //        if (LDLib2.isReiLoaded()) {
 //            REISupport.recipeSlot(this, io);
@@ -312,7 +312,7 @@ public class FluidSlot extends BindableUIElement<FluidStack> {
     public FluidSlot xeiRecipeSlot(IngredientIO io, float chance, int amount, Supplier<Stream<FluidStack>> allPossibleFluids) {
         // todo xei
         if (LDLib2.isJeiLoaded()) {
-            JEISupport.recipeSlot(this, allPossibleFluids);
+            JEISupport.recipeSlot(this, io, allPossibleFluids);
         }
 //        if (LDLib2.isReiLoaded()) {
 //            REISupport.recipeSlot(this, io, () -> allPossibleFluids);
@@ -571,11 +571,19 @@ public class FluidSlot extends BindableUIElement<FluidStack> {
         }
 
         public static void recipeSlot(FluidSlot fluidSlot) {
-            recipeSlot(fluidSlot, () -> Stream.of(fluidSlot.getFluid()));
+            recipeSlot(fluidSlot, IngredientIO.NONE);
+        }
+
+        public static void recipeSlot(FluidSlot fluidSlot, IngredientIO io) {
+            recipeSlot(fluidSlot, io, () -> Stream.of(fluidSlot.getFluid()));
         }
 
         public static void recipeSlot(FluidSlot fluidSlot, Supplier<Stream<FluidStack>> allPossibleFluids) {
-            LDLibJEIPlugin.recipeSlot(fluidSlot, () -> {
+            recipeSlot(fluidSlot, IngredientIO.NONE, allPossibleFluids);
+        }
+
+        public static void recipeSlot(FluidSlot fluidSlot, IngredientIO io, Supplier<Stream<FluidStack>> allPossibleFluids) {
+            LDLibJEIPlugin.recipeSlot(fluidSlot, io, () -> {
                 var fluid = fluidSlot.getValue();
                 return fluid.isEmpty() ? null : LDLibJEIPlugin
                         .createTypedIngredient(NeoForgeTypes.FLUID_STACK, fluidSlot.getFluid())

--- a/src/main/java/com/lowdragmc/lowdraglib2/gui/ui/elements/ItemSlot.java
+++ b/src/main/java/com/lowdragmc/lowdraglib2/gui/ui/elements/ItemSlot.java
@@ -260,7 +260,7 @@ public class ItemSlot extends BindableUIElement<ItemStack> {
     public ItemSlot xeiRecipeSlot(IngredientIO io, float chance) {
         // todo xei
         if (LDLib2.isJeiLoaded()) {
-            JEISupport.recipeSlot(this);
+            JEISupport.recipeSlot(this, io);
         }
 //        if (LDLib2.isReiLoaded()) {
 //            REISupport.recipeSlot(this, io);
@@ -274,7 +274,7 @@ public class ItemSlot extends BindableUIElement<ItemStack> {
     public ItemSlot xeiRecipeSlot(IngredientIO io, float chance, int amount, Supplier<Stream<ItemStack>> allPossibleItems) {
         // todo xei
         if (LDLib2.isJeiLoaded()) {
-            JEISupport.recipeSlot(this, allPossibleItems);
+            JEISupport.recipeSlot(this, io, allPossibleItems);
         }
 //        if (LDLib2.isReiLoaded()) {
 //            REISupport.recipeSlot(this, io, () -> allPossibleItems);
@@ -444,11 +444,19 @@ public class ItemSlot extends BindableUIElement<ItemStack> {
         }
 
         public static void recipeSlot(ItemSlot itemSlot) {
-            recipeSlot(itemSlot, () -> Stream.of(itemSlot.getValue()));
+            recipeSlot(itemSlot, IngredientIO.NONE);
+        }
+
+        public static void recipeSlot(ItemSlot itemSlot, IngredientIO io) {
+            recipeSlot(itemSlot, io, () -> Stream.of(itemSlot.getValue()));
         }
 
         public static void recipeSlot(ItemSlot itemSlot, Supplier<Stream<ItemStack>> allPossibleItems) {
-            LDLibJEIPlugin.recipeSlot(itemSlot, () -> {
+            recipeSlot(itemSlot, IngredientIO.NONE, allPossibleItems);
+        }
+
+        public static void recipeSlot(ItemSlot itemSlot, IngredientIO io, Supplier<Stream<ItemStack>> allPossibleItems) {
+            LDLibJEIPlugin.recipeSlot(itemSlot, io, () -> {
                 var item = itemSlot.getValue();
                 return item.isEmpty() ? null : TypedItemStack.create(item);
             }, () ->allPossibleItems.get().map(TypedItemStack::create).collect(Collectors.toList()));

--- a/src/main/java/com/lowdragmc/lowdraglib2/integration/xei/jei/JEIUIEvents.java
+++ b/src/main/java/com/lowdragmc/lowdraglib2/integration/xei/jei/JEIUIEvents.java
@@ -10,5 +10,6 @@ public final class JEIUIEvents {
     public static final String CLICKABLE_INGREDIENT = "clickableIngredient";
     public static final String GHOST_INGREDIENT = "ghostIngredient";
     public static final String RECIPE_INGREDIENT = "recipeIngredient";
+    public static final String RECIPE_SLOT = "recipeSlot";
     public static final String RECIPE_WIDGET = "recipeWidget";
 }

--- a/src/main/java/com/lowdragmc/lowdraglib2/integration/xei/jei/LDLibJEIPlugin.java
+++ b/src/main/java/com/lowdragmc/lowdraglib2/integration/xei/jei/LDLibJEIPlugin.java
@@ -242,10 +242,13 @@ public class LDLibJEIPlugin implements IModPlugin {
         }
         // Register a real layout slot in setRecipe so JEI transfer handlers and other JEI-API
         // consumers (quick-transfer, bookmarks, show recipes/uses) can see and use this ingredient.
-        var slotName = SLOT_NAME_PREFIX + RECIPE_SLOT_IDS.getAndIncrement();
+        // Assigned at UI build time, so it increases in the order xeiRecipeSlot is called
+        // (document order); used to register the layout slots in that same order.
+        var order = RECIPE_SLOT_IDS.getAndIncrement();
+        var slotName = SLOT_NAME_PREFIX + order;
         element.addEventListener(JEIUIEvents.RECIPE_SLOT, event -> {
             if (event.customData instanceof JEIRecipeSlotHandler recipeSlots) {
-                recipeSlots.addSlot(createRecipeSlotEntry(element, ingredientIO, displayIngredient, allIngredients, slotName));
+                recipeSlots.addSlot(createRecipeSlotEntry(element, ingredientIO, displayIngredient, allIngredients, order, slotName));
             }
         });
         // In createRecipeExtras, map this element's hover onto the JEI-created drawable(s) for that
@@ -272,12 +275,14 @@ public class LDLibJEIPlugin implements IModPlugin {
             IngredientIO ingredientIO,
             Supplier<ITypedIngredient<?>> displayIngredient,
             @Nullable Supplier<List<@org.jetbrains.annotations.Nullable ITypedIngredient<?>>> allIngredients,
+            int order,
             String slotName) {
         var area = LDLibJEIPlugin.getArea(element, true);
         var modularUI = element.getModularUI();
         var left = modularUI == null ? 0 : modularUI.getLeftPos();
         var top = modularUI == null ? 0 : modularUI.getTopPos();
         return new JEIRecipeSlotHandler.SlotEntry(
+                order,
                 getRole(ingredientIO),
                 area.getX() - Math.round(left),
                 area.getY() - Math.round(top),

--- a/src/main/java/com/lowdragmc/lowdraglib2/integration/xei/jei/LDLibJEIPlugin.java
+++ b/src/main/java/com/lowdragmc/lowdraglib2/integration/xei/jei/LDLibJEIPlugin.java
@@ -6,6 +6,7 @@ import com.lowdragmc.lowdraglib2.gui.holder.ModularUIScreen;
 import com.lowdragmc.lowdraglib2.gui.ui.UIElement;
 import com.lowdragmc.lowdraglib2.integration.xei.IngredientIO;
 import com.lowdragmc.lowdraglib2.integration.xei.jei.handler.JEIRecipeIngredientHandler;
+import com.lowdragmc.lowdraglib2.integration.xei.jei.handler.JEIRecipeSlotHandler;
 import com.lowdragmc.lowdraglib2.integration.xei.jei.handler.JEIRecipeWidgetHandler;
 import com.lowdragmc.lowdraglib2.integration.xei.jei.handler.JEITargetsTypedHandler;
 import com.lowdragmc.lowdraglib2.test.xei.TestJEIPlugin;
@@ -13,6 +14,7 @@ import com.mojang.logging.annotations.MethodsReturnNonnullByDefault;
 import mezz.jei.api.IModPlugin;
 import mezz.jei.api.JeiPlugin;
 import mezz.jei.api.gui.builder.IClickableIngredientFactory;
+import mezz.jei.api.gui.inputs.RecipeSlotUnderMouse;
 import mezz.jei.api.ingredients.IIngredientType;
 import mezz.jei.api.ingredients.ITypedIngredient;
 import mezz.jei.api.recipe.RecipeIngredientRole;
@@ -35,11 +37,19 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @JeiPlugin
 @ParametersAreNonnullByDefault
 @MethodsReturnNonnullByDefault
 public class LDLibJEIPlugin implements IModPlugin {
+    /**
+     * Prefix for the unique name given to each registered recipe slot. The name is the only key that
+     * links the layout slot created in {@code setRecipe} (Phase 1) to the widget bound in
+     * {@code createRecipeExtras} (Phase 2), so it must be stable per element and unique within a recipe.
+     */
+    private static final String SLOT_NAME_PREFIX = "ldlib2:recipe_slot/";
+    private static final AtomicInteger RECIPE_SLOT_IDS = new AtomicInteger();
     @Nullable
     public static IJeiRuntime jeiRuntime;
     @Nullable
@@ -212,18 +222,69 @@ public class LDLibJEIPlugin implements IModPlugin {
      *                       {@link ITypedIngredient} instances to associate with the slot.
      */
     public static <T extends UIElement> void recipeSlot(T element,
+                                                        IngredientIO ingredientIO,
                                                         Supplier<ITypedIngredient<?>> displayIngredient,
                                                         @Nullable Supplier<List<@org.jetbrains.annotations.Nullable ITypedIngredient<?>>> allIngredients) {
-        element.addEventListener(JEIUIEvents.RECIPE_WIDGET, event -> {
-            if (event.customData instanceof JEIRecipeWidgetHandler recipeSlot) {
-                recipeSlot.addSlot(new JEIRecipeSlotWidget(
-                        recipeSlot.localToWorld,
-                        element::isMouseOverElement,
-                        displayIngredient,
-                        allIngredients,
-                        ((view, tooltip) -> tooltip.addAll(element.getStyle().tooltips().asList()))));
+        if (ingredientIO == IngredientIO.NONE) {
+            // No IO role, so there is nothing transferable to register as a layout slot.
+            // Just draw our own slot widget for the tooltip / lookup, as before.
+            element.addEventListener(JEIUIEvents.RECIPE_WIDGET, event -> {
+                if (event.customData instanceof JEIRecipeWidgetHandler recipeSlot) {
+                    recipeSlot.addSlot(new JEIRecipeSlotWidget(
+                            recipeSlot.localToWorld,
+                            element::isMouseOverElement,
+                            displayIngredient,
+                            allIngredients,
+                            ((view, tooltip) -> tooltip.addAll(element.getStyle().tooltips().asList()))));
+                }
+            });
+            return;
+        }
+        // Register a real layout slot in setRecipe so JEI transfer handlers and other JEI-API
+        // consumers (quick-transfer, bookmarks, show recipes/uses) can see and use this ingredient.
+        var slotName = SLOT_NAME_PREFIX + RECIPE_SLOT_IDS.getAndIncrement();
+        element.addEventListener(JEIUIEvents.RECIPE_SLOT, event -> {
+            if (event.customData instanceof JEIRecipeSlotHandler recipeSlots) {
+                recipeSlots.addSlot(createRecipeSlotEntry(element, ingredientIO, displayIngredient, allIngredients, slotName));
             }
         });
+        // In createRecipeExtras, map this element's hover onto the JEI-created drawable(s) for that
+        // layout slot. The drawables are resolved once per render here, not on every mouse query.
+        element.addEventListener(JEIUIEvents.RECIPE_WIDGET, event -> {
+            if (event.customData instanceof JEIRecipeWidgetHandler recipeSlot) {
+                var createdSlots = JEIRecipeSlotHandler.findByName(recipeSlot.recipeSlots.get(), slotName);
+                recipeSlot.addSlot(
+                        (mouseX, mouseY) -> {
+                            for (var slot : createdSlots) {
+                                if (slot.isMouseOver(mouseX, mouseY)) {
+                                    return new RecipeSlotUnderMouse(slot, 0, 0);
+                                }
+                            }
+                            return null;
+                        },
+                        () -> createdSlots);
+            }
+        });
+    }
+
+    private static <T extends UIElement> JEIRecipeSlotHandler.SlotEntry createRecipeSlotEntry(
+            T element,
+            IngredientIO ingredientIO,
+            Supplier<ITypedIngredient<?>> displayIngredient,
+            @Nullable Supplier<List<@org.jetbrains.annotations.Nullable ITypedIngredient<?>>> allIngredients,
+            String slotName) {
+        var area = LDLibJEIPlugin.getArea(element, true);
+        var modularUI = element.getModularUI();
+        var left = modularUI == null ? 0 : modularUI.getLeftPos();
+        var top = modularUI == null ? 0 : modularUI.getTopPos();
+        return new JEIRecipeSlotHandler.SlotEntry(
+                getRole(ingredientIO),
+                area.getX() - Math.round(left),
+                area.getY() - Math.round(top),
+                displayIngredient,
+                allIngredients,
+                ((view, tooltip) -> tooltip.addAll(element.getStyle().tooltips().asList())),
+                slotName);
     }
 
 }

--- a/src/main/java/com/lowdragmc/lowdraglib2/integration/xei/jei/ModularUIRecipeCategory.java
+++ b/src/main/java/com/lowdragmc/lowdraglib2/integration/xei/jei/ModularUIRecipeCategory.java
@@ -9,6 +9,7 @@ import com.lowdragmc.lowdraglib2.gui.ui.event.UIEvent;
 import com.lowdragmc.lowdraglib2.gui.ui.event.UIEventDispatcher;
 import com.lowdragmc.lowdraglib2.gui.ui.utils.IModularUIProvider;
 import com.lowdragmc.lowdraglib2.integration.xei.jei.handler.JEIRecipeIngredientHandler;
+import com.lowdragmc.lowdraglib2.integration.xei.jei.handler.JEIRecipeSlotHandler;
 import com.lowdragmc.lowdraglib2.integration.xei.jei.handler.JEIRecipeWidgetHandler;
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
 import mezz.jei.api.gui.inputs.RecipeSlotUnderMouse;
@@ -20,7 +21,6 @@ import com.mojang.logging.annotations.MethodsReturnNonnullByDefault;
 import net.minecraft.client.gui.navigation.ScreenPosition;
 
 import javax.annotation.ParametersAreNonnullByDefault;
-import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
@@ -76,6 +76,13 @@ public abstract class ModularUIRecipeCategory<T> implements IRecipeCategory<T> {
         for (var focus : ingredientFocus.focuses) {
             builder.addInvisibleIngredients(focus.getA()).addTypedIngredients(focus.getB());
         }
+
+        var recipeSlots = new JEIRecipeSlotHandler();
+        var slotEvent = UIEvent.create(JEIUIEvents.RECIPE_SLOT);
+        slotEvent.target = mui.ui.rootElement;
+        slotEvent.customData = recipeSlots;
+        UIEventDispatcher.dispatchAllChildren(slotEvent);
+        recipeSlots.registerLayoutSlots(builder);
     }
 
     @Override
@@ -86,24 +93,25 @@ public abstract class ModularUIRecipeCategory<T> implements IRecipeCategory<T> {
         builder.addGuiEventListener(widget);
 
         // post event to append recipe slots
-        var recipeSlot = new JEIRecipeWidgetHandler(widget::getLocalToWorld);
+        var recipeSlot = new JEIRecipeWidgetHandler(widget::getLocalToWorld, builder::getRecipeSlots);
         var event = UIEvent.create(JEIUIEvents.RECIPE_WIDGET);
         event.target = widget.modularUI.ui.rootElement;
         event.customData = recipeSlot;
         UIEventDispatcher.dispatchAllChildren(event);
 
         for (var slot : recipeSlot.slots) {
+            var handledSlots = slot.handledSlots().get();
             builder.addSlottedWidget(new ISlottedRecipeWidget() {
                 @Override
                 public Optional<RecipeSlotUnderMouse> getSlotUnderMouse(double mouseX, double mouseY) {
-                    return Optional.ofNullable(slot.getRecipeSlots(mouseX, mouseY));
+                    return Optional.ofNullable(slot.provider().getRecipeSlots(mouseX, mouseY));
                 }
 
                 @Override
                 public ScreenPosition getPosition() {
                     return ModularUIJEIWidget.ZERO;
                 }
-            }, List.of());
+            }, handledSlots);
         }
     }
 }

--- a/src/main/java/com/lowdragmc/lowdraglib2/integration/xei/jei/handler/JEIRecipeSlotHandler.java
+++ b/src/main/java/com/lowdragmc/lowdraglib2/integration/xei/jei/handler/JEIRecipeSlotHandler.java
@@ -1,0 +1,75 @@
+package com.lowdragmc.lowdraglib2.integration.xei.jei.handler;
+
+import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
+import mezz.jei.api.gui.ingredient.IRecipeSlotDrawable;
+import mezz.jei.api.gui.ingredient.IRecipeSlotDrawablesView;
+import mezz.jei.api.gui.ingredient.IRecipeSlotRichTooltipCallback;
+import mezz.jei.api.ingredients.ITypedIngredient;
+import mezz.jei.api.recipe.RecipeIngredientRole;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+public final class JEIRecipeSlotHandler {
+    private final List<SlotEntry> slots = new ArrayList<>();
+
+    public void addSlot(SlotEntry slot) {
+        slots.add(slot);
+    }
+
+    public void registerLayoutSlots(IRecipeLayoutBuilder builder) {
+        for (var slot : slots) {
+            if (slot.role() == RecipeIngredientRole.RENDER_ONLY) {
+                continue;
+            }
+            var ingredients = slot.ingredients();
+            if (ingredients.isEmpty()) {
+                continue;
+            }
+            var slotBuilder = builder.addSlot(slot.role())
+                    .setPosition(slot.x(), slot.y())
+                    .addTypedIngredients(ingredients);
+            if (slot.tooltipCallback() != null) {
+                slotBuilder.addRichTooltipCallback(slot.tooltipCallback());
+            }
+            slotBuilder.setSlotName(slot.slotName());
+        }
+    }
+
+    /**
+     * Resolves the {@link IRecipeSlotDrawable}s that JEI created in {@code setRecipe} for the given slot name.
+     * Slots are registered with a stable name in {@link #registerLayoutSlots}, so a name match is enough -
+     * no need to rebuild the entry or fall back to ingredient comparison.
+     */
+    public static List<IRecipeSlotDrawable> findByName(IRecipeSlotDrawablesView view, String slotName) {
+        return view.getSlots().stream()
+                .filter(slot -> slot.getSlotName().map(slotName::equals).orElse(false))
+                .toList();
+    }
+
+    public record SlotEntry(
+            RecipeIngredientRole role,
+            int x,
+            int y,
+            Supplier<@Nullable ITypedIngredient<?>> displayedIngredient,
+            @Nullable Supplier<List<@Nullable ITypedIngredient<?>>> allIngredients,
+            @Nullable IRecipeSlotRichTooltipCallback tooltipCallback,
+            String slotName
+    ) {
+        public List<ITypedIngredient<?>> ingredients() {
+            if (allIngredients != null) {
+                var ingredients = allIngredients.get().stream()
+                        .filter(Objects::nonNull)
+                        .toList();
+                if (!ingredients.isEmpty()) {
+                    return ingredients;
+                }
+            }
+            var displayed = displayedIngredient.get();
+            return displayed == null ? List.of() : List.of(displayed);
+        }
+    }
+}

--- a/src/main/java/com/lowdragmc/lowdraglib2/integration/xei/jei/handler/JEIRecipeSlotHandler.java
+++ b/src/main/java/com/lowdragmc/lowdraglib2/integration/xei/jei/handler/JEIRecipeSlotHandler.java
@@ -9,6 +9,7 @@ import mezz.jei.api.recipe.RecipeIngredientRole;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Supplier;
@@ -21,7 +22,13 @@ public final class JEIRecipeSlotHandler {
     }
 
     public void registerLayoutSlots(IRecipeLayoutBuilder builder) {
-        for (var slot : slots) {
+        // dispatchAllChildren walks children in z-sorted (reverse insertion) order, so the entries are
+        // not collected in the order they were added to the tree. Register them by their declaration
+        // order (the order xeiRecipeSlot was called, i.e. document order) so transfer handlers
+        // (e.g. the AE2 pattern terminal) encode ingredients in the order the slots were added.
+        var ordered = new ArrayList<>(slots);
+        ordered.sort(Comparator.comparingInt(SlotEntry::order));
+        for (var slot : ordered) {
             if (slot.role() == RecipeIngredientRole.RENDER_ONLY) {
                 continue;
             }
@@ -51,6 +58,7 @@ public final class JEIRecipeSlotHandler {
     }
 
     public record SlotEntry(
+            int order,
             RecipeIngredientRole role,
             int x,
             int y,

--- a/src/main/java/com/lowdragmc/lowdraglib2/integration/xei/jei/handler/JEIRecipeWidgetHandler.java
+++ b/src/main/java/com/lowdragmc/lowdraglib2/integration/xei/jei/handler/JEIRecipeWidgetHandler.java
@@ -1,10 +1,10 @@
 package com.lowdragmc.lowdraglib2.integration.xei.jei.handler;
 
 import mezz.jei.api.gui.ingredient.IRecipeSlotDrawable;
+import mezz.jei.api.gui.ingredient.IRecipeSlotDrawablesView;
 import mezz.jei.api.gui.inputs.RecipeSlotUnderMouse;
 import org.jetbrains.annotations.Nullable;
 import org.joml.Matrix3x2f;
-import org.joml.Matrix4f;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -12,15 +12,25 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
 public final class JEIRecipeWidgetHandler {
-    public final List<RecipeSlotProvider> slots = new ArrayList<>();
+    public final List<SlotWidgetEntry> slots = new ArrayList<>();
     public final Supplier<Matrix3x2f> localToWorld;
+    public final Supplier<IRecipeSlotDrawablesView> recipeSlots;
 
     public JEIRecipeWidgetHandler(Supplier<Matrix3x2f> localToWorld) {
+        this(localToWorld, () -> List::of);
+    }
+
+    public JEIRecipeWidgetHandler(Supplier<Matrix3x2f> localToWorld, Supplier<IRecipeSlotDrawablesView> recipeSlots) {
         this.localToWorld = localToWorld;
+        this.recipeSlots = recipeSlots;
     }
 
     public void addSlot(RecipeSlotProvider slotUnderMouse) {
-        slots.add(slotUnderMouse);
+        addSlot(slotUnderMouse, List::of);
+    }
+
+    public void addSlot(RecipeSlotProvider slotUnderMouse, Supplier<List<IRecipeSlotDrawable>> handledSlots) {
+        slots.add(new SlotWidgetEntry(slotUnderMouse, handledSlots));
     }
 
     public void addSlot(IRecipeSlotDrawable slot) {
@@ -31,6 +41,8 @@ public final class JEIRecipeWidgetHandler {
             return null;
         });
     }
+
+    public record SlotWidgetEntry(RecipeSlotProvider provider, Supplier<List<IRecipeSlotDrawable>> handledSlots) {}
 
     @FunctionalInterface
     public interface RecipeSlotProvider extends BiFunction<Double, Double, RecipeSlotUnderMouse> {

--- a/src/main/java/com/lowdragmc/lowdraglib2/test/xei/TestRecipe.java
+++ b/src/main/java/com/lowdragmc/lowdraglib2/test/xei/TestRecipe.java
@@ -30,33 +30,28 @@ public class TestRecipe {
                 new UIElement().layout(layout -> layout.widthPercent(100).heightPercent(100)).addChildren(
                         new SplitView.Horizontal().left(new ScrollerView().addScrollViewChildren(
                                 new UIElement().layout(layout -> layout.gapAll(3)).addChildren(
-                                        // items
+                                        // items - registered as real layout slots with an IO role so JEI
+                                        // transfer handlers (e.g. AE2 pattern terminal "+") can read/encode them.
                                         new UIElement().addChildren(
                                                 new ItemSlot().setItem(Items.APPLE.getDefaultInstance())
-                                                        .xeiRecipeIngredient(IngredientIO.INPUT)
-                                                        .xeiRecipeSlot()
+                                                        .xeiRecipeSlot(IngredientIO.INPUT, 1)
                                                         .style(style -> style.tooltips("this is additional tooltips")),
                                                 new ItemSlot().setItem(Items.STONE.getDefaultInstance())
-                                                        .xeiRecipeIngredient(IngredientIO.INPUT)
                                                         .xeiRecipeSlot(IngredientIO.INPUT, 0.3f),
                                                 new UIElement().layout(layout -> layout.height(18).aspectRatio(1))
                                                         .style(style -> style.backgroundTexture(Icons.RIGHT_ARROW_NO_BAR)),
                                                 new ItemSlot().setItem(new ItemStack(Items.CHEST, 2))
-                                                        .xeiRecipeIngredient(IngredientIO.OUTPUT)
-                                                        .xeiRecipeSlot()
+                                                        .xeiRecipeSlot(IngredientIO.OUTPUT, 1)
                                         ).layout(layout -> layout.flexDirection(FlexDirection.ROW).wrap(FlexWrap.WRAP)),
                                         // fluids
                                         new UIElement().addChildren(
                                                 new FluidSlot().setFluid(new FluidStack(Fluids.WATER, 1000))
-                                                        .xeiRecipeIngredient(IngredientIO.INPUT)
-                                                        .xeiRecipeSlot(),
+                                                        .xeiRecipeSlot(IngredientIO.INPUT, 1),
                                                 new UIElement().layout(layout -> layout.height(18).aspectRatio(1))
                                                         .style(style -> style.backgroundTexture(Icons.RIGHT_ARROW_NO_BAR)),
                                                 new FluidSlot().setFluid(new FluidStack(Fluids.LAVA, 1000))
-                                                        .xeiRecipeIngredient(IngredientIO.OUTPUT)
-                                                        .xeiRecipeSlot(),
+                                                        .xeiRecipeSlot(IngredientIO.OUTPUT, 1),
                                                 new FluidSlot().setFluid(new FluidStack(Fluids.WATER, 30))
-                                                        .xeiRecipeIngredient(IngredientIO.OUTPUT)
                                                         .xeiRecipeSlot(IngredientIO.OUTPUT, 0.7f)
                                         ).layout(layout -> layout.flexDirection(FlexDirection.ROW).wrap(FlexWrap.WRAP)),
                                         new Button().setOnClick(event -> {
@@ -71,8 +66,7 @@ public class TestRecipe {
                                             }
                                         }),
                                         new ItemSlot().setItem(TestItem.ITEM.getDefaultInstance())
-                                                .xeiRecipeIngredient(IngredientIO.CATALYST)
-                                                .xeiRecipeSlot(),
+                                                .xeiRecipeSlot(IngredientIO.CATALYST, 1),
                                         new Label().setText("This is a Test")
                                 )
                         ).layout(layout -> layout.widthPercent(100).heightPercent(100)).addClass("panel_bg")).right(new UIElement().layout(layout -> layout.widthPercent(100).heightPercent(100)).addChildren(


### PR DESCRIPTION
# fix(jei)：将 `xeiRecipeSlot` 注册为真正的 JEI layout slot（支持快速转移）

## 背景 / 问题

`UIElement.xeiRecipeSlot(...)` 此前只在 JEI 的 `createRecipeExtras` 阶段添加一个 **自绘** slot（通过 `ISlottedRecipeWidget`），从未经由 `setRecipe` 阶段的 `IRecipeLayoutBuilder.addSlot(...)` 注册，因此这个槽不会进入 JEI 的 `IRecipeSlotsView`。

结果：所有基于 JEI API 读取配方槽的功能 —— JEI 自带的配方转移（`+`），以及 **AE2 样板终端的快速转移** —— 都看不到这些 ingredient，LDLib 配方的快速转移因此无法工作。

## 目标

让 `xeiRecipeSlot(io, ...)` 注册一个**带坐标、带 IngredientIO 角色的真 layout slot**，
使 JEI API 的消费方能够读取并转移它，同时仍由 LDLib 自己渲染该槽（不产生视觉重影）。

## 为什么新增一个 `RECIPE_SLOT` 事件（而非复用现有事件）

JEI 把"一个逻辑槽"拆到了两个回调里：

| JEI 回调 | 可用 builder | 能做什么 | 对应 LDLib 事件 |
|---|---|---|---|
| `setRecipe(IRecipeLayoutBuilder, …)` | 布局构建器 | `addSlot().setPosition().addTypedIngredients()` → 进入 `IRecipeSlotsView` 的**真槽** | `RECIPE_INGREDIENT`（不可见 focus）+ **`RECIPE_SLOT`**（新增） |
| `createRecipeExtras(IRecipeExtrasBuilder, …)` | 额外 widget 构建器 | 加 widget / 处理鼠标；layout slot 已建好，可经 `getRecipeSlots()` 读取 | `RECIPE_WIDGET` |

- **不能复用 `RECIPE_WIDGET`**：阶段不对 —— `createRecipeExtras` 里拿不到 `IRecipeLayoutBuilder`，无法调用 `addSlot()`。
- **不能干净地复用 `RECIPE_INGREDIENT`**：虽同在 `setRecipe` 阶段触发，但它语义是 "注册不可见 focus"（`addInvisibleIngredients`），载体也不同（`JEIRecipeIngredientHandler`）。"带坐标、可转移的槽"是另一个概念
  （`JEIRecipeSlotHandler`）。

因此一个槽需要在**两个阶段**各注册一次，靠一个稳定的 slot name 关联：
1. `RECIPE_SLOT`（Phase 1）→ 在布局构建器上声明位置 / 角色 / ingredient。
2. `RECIPE_WIDGET`（Phase 2）→ 按名字找到 JEI 创建的 drawable，把元素的 hover 绑定到它，并将其声明为 `handledSlots`，使 JEI 不再重绘（由 LDLib 渲染）。

## 改动内容

### 公共 API（向后兼容）
- `ItemSlot` / `FluidSlot`：
  - `xeiRecipeSlot(io, chance)` 与 `xeiRecipeSlot(io, chance, amount, allPossible)`
    现在会为给定的 `IngredientIO` 注册真 layout slot。
  - `xeiRecipeSlot()`（无参）仍映射为 `IngredientIO.NONE` → 行为不变（仅自绘，
    无 layout slot，不可转移）。
  - 新增 `JEISupport.recipeSlot(slot, io)` / `recipeSlot(slot, io, allPossible)`
    重载；旧的 `recipeSlot(slot)` / `recipeSlot(slot, allPossible)` 保留（默认 `NONE`）。
- `LDLibJEIPlugin.recipeSlot(...)` 新增 `IngredientIO ingredientIO` 参数。

### 机制
- **`JEIUIEvents`**：新增 `RECIPE_SLOT` 事件键。
- **`JEIRecipeSlotHandler`**（新增）：在 `setRecipe` 收集 `SlotEntry`，
  `registerLayoutSlots(builder)` 创建 JEI 槽；静态方法 `findByName(view, slotName)`
  在 `createRecipeExtras` 按名解析已创建的 drawable。
- **`JEIRecipeWidgetHandler`**：条目改为同时携带鼠标 provider 与 `handledSlots`
  supplier（`SlotWidgetEntry`）；新增 `recipeSlots` supplier（`builder::getRecipeSlots`），
  供 widget 阶段查找已创建的槽。
- **`ModularUIRecipeCategory`**：
  - `setRecipe` 派发 `RECIPE_SLOT` 并调用 `registerLayoutSlots`。
  - `createRecipeExtras` 把解析好的 `handledSlots` 传给 `addSlottedWidget(...)`，
    让 JEI 抑制对这些槽的自绘。
- **`LDLibJEIPlugin.recipeSlot`**：
  - `NONE` → 仅注册 `RECIPE_WIDGET` 自绘槽（提前 return）。
  - 非 `NONE` → 注册 `RECIPE_SLOT`（布局）+ `RECIPE_WIDGET`（绑定 drawable）；
    drawable 每次渲染**只解析一次**（不再每次鼠标移动重扫）。

### 清理
- `JEIRecipeSlotHandler.SlotEntry`：删除未使用的 `width`/`height` 字段、便利构造、以及 `defaultSlotName`/下标兜底；`slotName` 改为非空不变量。
- slot name 前缀提取为 `LDLibJEIPlugin.SLOT_NAME_PREFIX`，并注释说明它是 Phase-1 ↔ Phase-2 的关联键。
- 移除每次鼠标查询对槽视图的重复扫描（改为一次解析）。

### 测试
- `TestRecipe`：将各槽从 `xeiRecipeIngredient(io) + xeiRecipeSlot()` 的组合改为单条 `xeiRecipeSlot(io, chance)`（INPUT/OUTPUT/CATALYST）。原组合会把同一 ingredient 注册两次（不可见 + 可见）。

## 行为 / 兼容性说明
- 无视觉变化：layout slot 被声明为 LDLib slotted widget 的 `handledSlots`，JEI 不渲染，仍由 LDLib 的 `ItemSlot`/`FluidSlot` 绘制；layout slot 仅承担数据/转移/查找。
- 使用 `xeiRecipeSlot()`（无参）的既有调用不受影响。
- `CATALYST` 映射为 `CRAFTING_STATION`，因此催化剂会显示但不会被 transfer handler 编码为输入。

<img width="1691" height="1014" alt="PixPin_2026-06-16_20-30-04" src="https://github.com/user-attachments/assets/36ac6cb2-d4f9-4a85-8d90-cbbe2723658f" />
<img width="882" height="608" alt="PixPin_2026-06-16_20-30-18" src="https://github.com/user-attachments/assets/88de6278-2c87-442d-a8c4-379707879701" />
