### PR TITLE
Update file path normalization to be relative to game dir

### DIFF
--- a/src/main/java/com/lowdragmc/lowdraglib2/editor/resource/FilePath.java
+++ b/src/main/java/com/lowdragmc/lowdraglib2/editor/resource/FilePath.java
@@ -1,5 +1,6 @@
 package com.lowdragmc.lowdraglib2.editor.resource;
 
+import com.lowdragmc.lowdraglib2.Platform;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import net.minecraft.resources.ResourceLocation;
@@ -20,9 +21,10 @@ public final class FilePath implements IResourcePath {
 
     public static String normalizePath(String path) {
         if (path == null) return null;
-        return path.replace('\\', '/')
-                .replaceAll("/+", "/")
-                .replaceAll("/$", "");
+        var gamePath = Platform.getGamePath().toAbsolutePath().normalize();
+        var absolutePath = new File(path).toPath().toAbsolutePath().normalize();
+        var relativePath = absolutePath.startsWith(gamePath) ? gamePath.relativize(absolutePath) : absolutePath;
+        return relativePath.toString().replace('\\', '/');
     }
 
     public FilePath(String path) {


### PR DESCRIPTION
### Description
Based on [our discussion on Discord](https://discord.com/channels/980360897354682389/980361468652437527/1517129451765235783), I've updated `normalizePath` function to always return path relative to game directory.
The code is quite similar to what was already done in [`FileResourceProvider#serializeNBT`](https://github.com/Low-Drag-MC/LDLib2/blob/d66c8c6805b94372c1d624a359f06883c5004a08/src/main/java/com/lowdragmc/lowdraglib2/editor/resource/FileResourceProvider.java#L278-L285).