### PR TITLE
Fix recipes in EMI disappearing under certain conditions

### DIFF
--- a/src/main/java/com/lowdragmc/lowdraglib2/integration/xei/emi/handler/EMIRecipeIngredientHandler.java
+++ b/src/main/java/com/lowdragmc/lowdraglib2/integration/xei/emi/handler/EMIRecipeIngredientHandler.java
@@ -3,6 +3,7 @@ package com.lowdragmc.lowdraglib2.integration.xei.emi.handler;
 import com.lowdragmc.lowdraglib2.integration.xei.IngredientIO;
 import dev.emi.emi.api.stack.EmiIngredient;
 import dev.emi.emi.api.stack.EmiStack;
+import dev.emi.emi.api.stack.ListEmiIngredient;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -26,11 +27,16 @@ public final class EMIRecipeIngredientHandler {
 
     public void add(IngredientIO role, List<EmiIngredient> ingredients) {
         if (role == IngredientIO.INPUT) {
-            addInput(ingredients);
+            addInput(mergeVariants(ingredients));
         } else if (role == IngredientIO.CATALYST) {
-            addCatalyst(ingredients);
+            addCatalyst(mergeVariants(ingredients));
         } else if (role == IngredientIO.OUTPUT) {
             addOutput(ingredients.stream().flatMap(ingredient -> ingredient.getEmiStacks().stream()).toList());
         }
+    }
+
+    private static List<EmiIngredient> mergeVariants(List<EmiIngredient> ingredients) {
+        if (ingredients.size() < 2) return ingredients;
+        return List.of(new ListEmiIngredient(ingredients, ingredients.getFirst().getAmount()));
     }
 }


### PR DESCRIPTION
## Description
EMI lets stacks be disabled entirely from its index (via index/stacks data, or `EmiInitRegistry#disableStack` from a plugin). When baking recipes, EMI discards any recipe holding an ingredient whose stacks are all disabled. A tag ingredient therefore survives as long as one of its variants is still enabled.

## Cause
Mods using LDLib hand the stacks a single slot accepts, already resolved from the tag (in MBD2, `ItemRecipeCapability` passes `Arrays.stream(ingredient.getItems())`). `EMIRecipeIngredientHandler` reports each of those as its own
single-stack ingredient rather than one ingredient holding all the variants. Whenever EMI encounters a disabled single-stack ingredient, it drops the entire recipe, even though every other variant is still available  ([see related EMI code](https://github.com/emilyploszaj/emi/blob/c0b5723159f22c0b4b805bb73b12d299c7350eb3/xplat/src/main/java/dev/emi/emi/registry/EmiRecipes.java#L90-L98))

## Solution
This PR merges all the variants back into a `ListEmiIngredient` via `EmiIngredient#of` factory. Similar approach was already used in LDLib, but in a different place ([see related LDLib code](https://github.com/Low-Drag-MC/LDLib2/blob/34bc14e495e28f4ceb9a536a40e69655107799d3/src/main/java/com/lowdragmc/lowdraglib2/gui/ui/elements/ItemSlot.java#L613-L616)). That approach was also changed: `ListEmiIngredient` was replaced with `EmiIngredient#of` factory so that disabled ingredients won't be shown on separate EMI possible items list screen.

## Reproduction

Minimal modpack:
[LDLibRepro.zip](https://github.com/user-attachments/files/30120551/LDLibRepro.zip)

Add/remove `kubejs/assets/emi/index/stacks/repro.json` to see changes. Adding a file disables `minecraft:oak_planks` in EMI, removing the file brings them back.

### Before the PR
Look at `minecraft:torch` recipe in EMI: recipe **WILL NOT** be shown in EMI for `repro:emi` recipe type

### After the PR
Look at `minecraft:torch` recipe in EMI: recipe **WILL** be shown in EMI for `repro:emi` recipe type

## Notes
- In MBD2, item cycling slot still shows disabled stacks in EMI. This is unrelated to LDLib, because MBD2 itself passes all possible ingredient items to `ScrollDataSource` ([see related MBD2 code](https://github.com/Low-Drag-MC/Multiblocked2/blob/af77da44ff1bd99322ff3247ec62643d84298234/src/main/java/com/lowdragmc/mbd2/common/capability/recipe/ItemRecipeCapability.java#L62-L68)). For that to be fixed, MBD2 has to do filtering on its side, but that's too much machinery just for cosmetics.
- This PR implementation might not be the best, but it proves the incompatibility with EMI stack disabling feature. Other recipe viewers aren't affected as they all seem to not have a concept of disabling stacks.